### PR TITLE
Pull strings out for i18n

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     })
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-
     compile 'org.glassfish:javax.annotation:10.0-b28'
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:design:25.1.0'

--- a/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
@@ -48,7 +48,7 @@ class LoginActivity : AppCompatActivity() {
 
 
                                 } else {
-                                    Toast.makeText(this@LoginActivity, "Incorrect details", Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(this@LoginActivity, getString(R.string.error_incorrect_details), Toast.LENGTH_SHORT).show()
                                 }
                             }
 

--- a/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
@@ -3,8 +3,6 @@ package org.standardnotes.notes
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.view.View
-import android.view.View.OnClickListener
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
@@ -20,7 +18,6 @@ import retrofit2.Response
  * A login screen that offers login via email/password.
  */
 class LoginActivity : AppCompatActivity() {
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -71,7 +68,5 @@ class LoginActivity : AppCompatActivity() {
             })
         }
     }
-
-
 }
 

--- a/app/src/main/java/org/standardnotes/notes/MainActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/MainActivity.kt
@@ -47,8 +47,4 @@ class MainActivity : AppCompatActivity() {
         finish()
         return true
     }
-
-
-
-
 }

--- a/app/src/main/java/org/standardnotes/notes/MainActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : AppCompatActivity() {
         val toolbar = findViewById(R.id.toolbar) as Toolbar
         setSupportActionBar(toolbar)
 
-        title = "Standard Notes"
+        title = getString(R.string.app_name)
 
         fab.setOnClickListener { view ->
             (supportFragmentManager.findFragmentById(R.id.noteListFrag) as NoteListFragment).startNewNote()
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
-        val item = menu.add("Log out")
+        val item = menu.add(getString(R.string.action_logout))
         item.setIcon(android.R.drawable.ic_menu_search)
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
         return true

--- a/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
@@ -6,12 +6,7 @@ import android.support.v4.app.NavUtils
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import android.view.WindowManager
-import org.standardnotes.notes.comms.data.Note
 import org.standardnotes.notes.frag.NoteFragment
-
-/**
- * Created by carl on 15/01/17.
- */
 
 class NoteActivity : AppCompatActivity() {
 
@@ -41,5 +36,4 @@ class NoteActivity : AppCompatActivity() {
         }
         return super.onOptionsItemSelected(item)
     }
-
 }

--- a/app/src/main/java/org/standardnotes/notes/SApplication.kt
+++ b/app/src/main/java/org/standardnotes/notes/SApplication.kt
@@ -10,10 +10,6 @@ import org.standardnotes.notes.comms.CommsManager
 import org.standardnotes.notes.store.NoteStore
 import org.standardnotes.notes.store.ValueStore
 
-/**
- * Created by carl on 03/01/17.
- */
-
 class SApplication : Application() {
     val comms: CommsManager by lazy { CommsManager("https://n3.standardnotes.org") }
     val valueStore: ValueStore by lazy { ValueStore(this) }
@@ -31,5 +27,4 @@ class SApplication : Application() {
         var instance: SApplication? = null
             private set
     }
-
 }

--- a/app/src/main/java/org/standardnotes/notes/StarterActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/StarterActivity.kt
@@ -4,10 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 
-/**
- * Created by carl on 15/01/17.
- */
-
 class StarterActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/standardnotes/notes/UiUtil.kt
+++ b/app/src/main/java/org/standardnotes/notes/UiUtil.kt
@@ -2,10 +2,6 @@ package org.standardnotes.notes
 
 import android.util.TypedValue
 
-/**
- * Created by carl on 18/01/17.
- */
-
 fun Int.dpToPixels(): Int {
     val metrics = SApplication.instance!!.resources.displayMetrics
     return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, this.toFloat(), metrics).toInt()

--- a/app/src/main/java/org/standardnotes/notes/comms/CommsManager.kt
+++ b/app/src/main/java/org/standardnotes/notes/comms/CommsManager.kt
@@ -3,12 +3,7 @@ package org.standardnotes.notes.comms
 import com.google.gson.*
 import org.standardnotes.notes.SApplication
 
-import java.io.IOException
-
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -16,10 +11,6 @@ import org.joda.time.format.ISODateTimeFormat
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.lang.reflect.Type
-
-/**
- * Created by carl on 03/01/17.
- */
 
 class CommsManager(serverBaseUrl: String) {
 

--- a/app/src/main/java/org/standardnotes/notes/comms/Crypt.java
+++ b/app/src/main/java/org/standardnotes/notes/comms/Crypt.java
@@ -2,7 +2,6 @@ package org.standardnotes.notes.comms;
 
 import android.util.Base64;
 
-import org.joda.time.DateTime;
 import org.spongycastle.crypto.digests.SHA512Digest;
 import org.spongycastle.crypto.generators.PKCS5S2ParametersGenerator;
 import org.spongycastle.crypto.params.KeyParameter;
@@ -25,10 +24,6 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import kotlin.text.Charsets;
-
-/**
- * Created by carl on 14/01/17.
- */
 
 public class Crypt {
 
@@ -60,7 +55,6 @@ public class Crypt {
         return encrypt(keyHex, SApplication.Companion.getInstance().getValueStore().getMasterKey());
     }
 
-
     public static Keys getItemKeys(EncryptedItem item) throws Exception {
         String itemKey = decrypt(item.getEncItemKey(), SApplication.Companion.getInstance().getValueStore().getMasterKey());
         Keys val = new Keys();
@@ -88,8 +82,6 @@ public class Crypt {
         String base64Encr = Base64.encodeToString(resultData, Base64.NO_WRAP);
         return base64Encr;
     }
-
-
 
     final protected static char[] hexArray = "0123456789abcdef".toCharArray();
     public static String bytesToHex(byte[] bytes) {
@@ -142,8 +134,6 @@ public class Crypt {
         return tagDecryptor.decrypt(item);
     }
 
-
-
     private static String createHash(String text, String ak) throws NoSuchAlgorithmException, InvalidKeyException {
         // TODO make use spongycastle
         byte[] contentData = text.getBytes(Charsets.UTF_8);
@@ -153,7 +143,6 @@ public class Crypt {
         sha256_HMAC.init(secret_key);
         return Crypt.bytesToHex(sha256_HMAC.doFinal(contentData));
     }
-
 
     static void copyInEncryptableItemFields(EncryptableItem source, EncryptableItem target) {
         target.setUuid(source.getUuid());
@@ -166,6 +155,7 @@ public class Crypt {
 
     static class ContentDecryptor<T extends EncryptableItem> {
         private Class<T> type;
+
         public ContentDecryptor(Class<T> type) {
             this.type = type;
         }
@@ -201,6 +191,5 @@ public class Crypt {
             return null;
         }
     }
-
 }
 

--- a/app/src/main/java/org/standardnotes/notes/comms/ServerApi.java
+++ b/app/src/main/java/org/standardnotes/notes/comms/ServerApi.java
@@ -13,10 +13,6 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
 
-/**
- * Created by carl on 04/01/17.
- */
-
 public interface ServerApi {
 
     @GET("/api/auth/params/")
@@ -28,5 +24,4 @@ public interface ServerApi {
 
     @POST("/api/items/sync/")
     Call<SyncItems> sync(@Body UploadSyncItems data);
-
 }

--- a/app/src/main/java/org/standardnotes/notes/comms/data/ContentType.kt
+++ b/app/src/main/java/org/standardnotes/notes/comms/data/ContentType.kt
@@ -1,16 +1,11 @@
 package org.standardnotes.notes.comms.data
 
-/**
- * Created by carl on 19/01/17.
- */
-
 enum class ContentType {
     Note, Tag;
 
     override fun toString(): String {
         return if (this == Note) "Note" else "Tag"
     }
-
 }
 
 fun contentTypeFromString(str: String?): ContentType? {

--- a/app/src/main/java/org/standardnotes/notes/frag/NoteFragment.kt
+++ b/app/src/main/java/org/standardnotes/notes/frag/NoteFragment.kt
@@ -23,7 +23,7 @@ class NoteFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val noteUuid = arguments?.getString("noteId")
+        val noteUuid = arguments?.getString(NoteListFragment.NOTE_FRAGMENT_INTENT)
         if (noteUuid != null) {
             note = SApplication.instance!!.noteStore.getNote(noteUuid)
             tags = SApplication.instance!!.noteStore.getTagsForNote(noteUuid)

--- a/app/src/main/java/org/standardnotes/notes/frag/NoteFragment.kt
+++ b/app/src/main/java/org/standardnotes/notes/frag/NoteFragment.kt
@@ -16,10 +16,6 @@ import org.standardnotes.notes.comms.Crypt
 import org.standardnotes.notes.comms.data.Tag
 import java.util.*
 
-/**
- * Created by carl on 15/01/17.
- */
-
 class NoteFragment : Fragment() {
 
     var note: Note? = null
@@ -74,8 +70,6 @@ class NoteFragment : Fragment() {
             }
         }
     }
-
-
 }
 
 fun newNote(): Note {

--- a/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
+++ b/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
@@ -3,14 +3,12 @@ package org.standardnotes.notes.frag
 import android.content.Intent
 import android.graphics.Canvas
 import android.graphics.Paint
-import android.graphics.Rect
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.PopupMenu
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
-import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -32,7 +30,6 @@ import java.util.*
 
 
 class NoteListFragment : Fragment() {
-
 
     private val REQ_EDIT_NOTE: Int = 1
 
@@ -182,5 +179,4 @@ class NoteListFragment : Fragment() {
         }
 
     }
-
 }

--- a/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
+++ b/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
@@ -37,6 +37,10 @@ class NoteListFragment : Fragment() {
 
     var notes = ArrayList<Note>()
 
+    companion object {
+        const val NOTE_FRAGMENT_INTENT = "noteId"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
     }
@@ -112,7 +116,7 @@ class NoteListFragment : Fragment() {
             }
 
             override fun onFailure(call: Call<SyncItems>, t: Throwable) {
-                Toast.makeText(activity, "Failed to sync", Toast.LENGTH_SHORT).show()
+                Toast.makeText(activity, activity.getString(R.string.error_fail_sync), Toast.LENGTH_SHORT).show()
                 swipeRefreshLayout.isRefreshing = false
             }
         })
@@ -144,12 +148,12 @@ class NoteListFragment : Fragment() {
         init {
             itemView.setOnClickListener {
                 val intent: Intent = Intent(activity, NoteActivity::class.java)
-                intent.putExtra("noteId", note?.uuid)
+                intent.putExtra(NOTE_FRAGMENT_INTENT, note?.uuid)
                 startActivityForResult(intent, REQ_EDIT_NOTE)
             }
             itemView.setOnLongClickListener {
                 val popup = PopupMenu(activity, itemView)
-                popup.menu.add("Delete")
+                popup.menu.add(activity.getString(R.string.action_delete))
                 popup.setOnMenuItemClickListener {
                     SApplication.instance!!.noteStore.deleteItem(note!!.uuid)
                     notes = ArrayList(SApplication.instance!!.noteStore.notesList)

--- a/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
+++ b/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
@@ -10,11 +10,6 @@ import org.standardnotes.notes.comms.Crypt
 import org.standardnotes.notes.comms.data.*
 import java.util.*
 
-/**
- * Created by carl on 17/01/17.
- */
-
-
 val CURRENT_DB_VERSION: Int = 1
 
 // TODO move this to async access
@@ -328,8 +323,6 @@ class NoteStore : SQLiteOpenHelper(SApplication.instance, "note", null, CURRENT_
         close()
         SApplication.instance!!.deleteDatabase("note")
     }
-
-
 }
 
 private fun EncryptedItem.isValid(): Boolean {

--- a/app/src/main/java/org/standardnotes/notes/store/ValueStore.kt
+++ b/app/src/main/java/org/standardnotes/notes/store/ValueStore.kt
@@ -3,10 +3,6 @@ package org.standardnotes.notes.store
 import android.content.Context
 import android.content.SharedPreferences
 
-/**
- * Created by carl on 03/01/17.
- */
-
 class ValueStore(context: Context) {
 
     private val prefs: SharedPreferences = context.getSharedPreferences("values", Context.MODE_PRIVATE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,5 +10,11 @@
     <string name="error_invalid_password">This password is too short</string>
     <string name="error_incorrect_password">This password is incorrect</string>
     <string name="error_field_required">This field is required</string>
+    <string name="error_incorrect_details">Incorrect details</string>
     <string name="title_activity_main">MainActivity</string>
+    <string name="action_logout">Log out</string>
+
+    <!-- Strings related to notes -->
+    <string name="action_delete">Delete</string>
+    <string name="error_fail_sync">Failed to sync</string>
 </resources>


### PR DESCRIPTION
This is regarding https://github.com/standardnotes/android/issues/14

Obviously these won't be the only strings that need to be translatable in the future. I propose that maintainers just use `strings.xml` right away instead of leaving text in the code.

Also this builds on my other PR, but that shouldn't be a big deal. I can rebase depending on the maintainer's approval 👍 