### PR TITLE
Downgrade minSdkVersion to 16 -> SQLite bug not applicable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "24.0.3"
     defaultConfig {
         applicationId "org.standardnotes.notes"
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "0.0.1"

--- a/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
+++ b/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
@@ -62,6 +62,7 @@ class NoteStore : SQLiteOpenHelper(SApplication.instance, "note", null, CURRENT_
         val db = writableDatabase
 
         // TODO gotcha for when adding pre-lollipop support http://stackoverflow.com/questions/39430179/kotlin-closable-and-sqlitedatabase-on-android
+        // Necessary changes were introduced in API 16 -> Safe to downgrade minSdkVersion to 16
         db.use {
             db.beginTransaction()
             db.delete(TABLE_NOTE, "$KEY_UUID=?", arrayOf(uuid))


### PR DESCRIPTION
If bug with SQLiteDB not implementing Closable interface is the only one requiring API level 21, then it's safe to downgrade min level to 16 