### PR TITLE
Let users enable screenshots

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,9 +40,13 @@ dependencies {
     })
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    compile 'org.glassfish:javax.annotation:10.0-b28'
     compile "com.android.support:appcompat-v7:$android_support"
     compile "com.android.support:design:$android_support"
+    compile "com.android.support:support-v4:$android_support"
+    compile "com.android.support:recyclerview-v7:$android_support"
+    compile "com.android.support:preference-v7:$android_support"
+    compile "com.android.support:preference-v14:$android_support"
+    compile 'org.glassfish:javax.annotation:10.0-b28'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
@@ -52,8 +56,6 @@ dependencies {
     compile 'com.madgag.spongycastle:prov:1.54.0.0'
     compile 'com.madgag.spongycastle:pkix:1.54.0.0'
     compile 'com.madgag.spongycastle:pg:1.54.0.0'
-    compile "com.android.support:support-v4:$android_support"
-    compile "com.android.support:recyclerview-v7:$android_support"
     compile 'net.danlew:android.joda:2.9.4.1'
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,20 +6,17 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
+        android:name=".SApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:name=".SApplication"
         android:theme="@style/AppTheme">
-        <activity
-            android:name=".StarterActivity"
-            >
+        <activity android:name=".StarterActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -28,16 +25,17 @@
         </activity>
         <activity
             android:name=".LoginActivity"
-            android:label="@string/app_name">
-        </activity>
+            android:label="@string/app_name" />
         <activity
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".NoteActivity"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            />
+            android:windowSoftInputMode="stateHidden|adjustResize" />
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/action_settings"
+            android:parentActivityName=".MainActivity" />
     </application>
-
 </manifest>

--- a/app/src/main/java/org/standardnotes/notes/BaseActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/BaseActivity.kt
@@ -1,0 +1,58 @@
+package org.standardnotes.notes
+
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.support.v7.app.AppCompatActivity
+import android.view.WindowManager
+import android.widget.Toast
+
+open class BaseActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private val KEY_ENABLE_SCREENSHOT = "enable_screenshots"
+    lateinit var prefs: SharedPreferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        prefs = PreferenceManager.getDefaultSharedPreferences(this)
+
+        if (!isScreenshottingEnabled()) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        when(key) {
+            KEY_ENABLE_SCREENSHOT ->
+
+                if (isScreenshottingEnabled()) enableScreenshots() else disableScreenshots()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        prefs.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        prefs.unregisterOnSharedPreferenceChangeListener(this)
+    }
+
+    private fun disableScreenshots() {
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE)
+        Toast.makeText(this, R.string.toast_screenshots_disabled, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun enableScreenshots() {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        Toast.makeText(this, R.string.toast_screenshots_enabled, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun isScreenshottingEnabled(): Boolean {
+        return prefs.getBoolean(KEY_ENABLE_SCREENSHOT, false)
+    }
+}

--- a/app/src/main/java/org/standardnotes/notes/MainActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/MainActivity.kt
@@ -1,36 +1,18 @@
 package org.standardnotes.notes
 
 import android.content.Intent
-import android.content.SharedPreferences
+
 import android.os.Bundle
-import android.preference.PreferenceManager
-import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
-import android.view.WindowManager
-import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_main.*
 import org.standardnotes.notes.frag.NoteListFragment
 
-class MainActivity : AppCompatActivity() {
-
-    companion object {
-        const val IS_SCREENSHOTTING_ENABLED = "toggle_screenshots"
-    }
-    lateinit var prefs: SharedPreferences
-    lateinit var editor: SharedPreferences.Editor
+class MainActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        editor = prefs.edit()
-
-        if (!isScreenshottingEnabled()) {
-            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                    WindowManager.LayoutParams.FLAG_SECURE)
-        }
 
         setContentView(R.layout.activity_main)
         val toolbar = findViewById(R.id.toolbar) as Toolbar
@@ -53,19 +35,10 @@ class MainActivity : AppCompatActivity() {
         return true
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        if (!isScreenshottingEnabled()) {
-            menu?.findItem(R.id.toggleScreenshot)?.setTitle(R.string.action_enable_screenshots)
-        } else {
-            menu?.findItem(R.id.toggleScreenshot)?.setTitle(R.string.action_disable_screenshots)
-        }
-        return super.onPrepareOptionsMenu(menu)
-    }
-
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         when (item?.itemId) {
             R.id.logout -> logout()
-            R.id.toggleScreenshot -> if (isScreenshottingEnabled()) disableScreenshots() else enableScreenshots()
+            R.id.settings -> startActivity(Intent(this, SettingsActivity::class.java))
         }
         return true
     }
@@ -75,25 +48,5 @@ class MainActivity : AppCompatActivity() {
         SApplication.instance!!.noteStore.deleteAll()
         startActivity(Intent(this, StarterActivity::class.java))
         finish()
-    }
-
-    private fun disableScreenshots() {
-        editor.putBoolean(IS_SCREENSHOTTING_ENABLED, false)
-        editor.commit()
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE)
-        Toast.makeText(this, R.string.toast_screenshots_disabled, Toast.LENGTH_SHORT).show()
-    }
-
-    private fun enableScreenshots() {
-        editor.putBoolean(IS_SCREENSHOTTING_ENABLED, true)
-        editor.commit()
-        finish()
-        startActivity(intent)
-        Toast.makeText(this, R.string.toast_screenshots_enabled, Toast.LENGTH_SHORT).show()
-    }
-
-    private fun isScreenshottingEnabled(): Boolean {
-        return prefs.getBoolean(IS_SCREENSHOTTING_ENABLED, false)
     }
 }

--- a/app/src/main/java/org/standardnotes/notes/MainActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/MainActivity.kt
@@ -1,21 +1,37 @@
 package org.standardnotes.notes
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.preference.PreferenceManager
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
 import android.view.WindowManager
+import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_main.*
 import org.standardnotes.notes.frag.NoteListFragment
 
 class MainActivity : AppCompatActivity() {
 
+    companion object {
+        const val IS_SCREENSHOTTING_ENABLED = "toggle_screenshots"
+    }
+    lateinit var prefs: SharedPreferences
+    lateinit var editor: SharedPreferences.Editor
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE)
+
+        prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        editor = prefs.edit()
+
+        if (!isScreenshottingEnabled()) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         setContentView(R.layout.activity_main)
         val toolbar = findViewById(R.id.toolbar) as Toolbar
         setSupportActionBar(toolbar)
@@ -33,18 +49,51 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
-        val item = menu.add(getString(R.string.action_logout))
-        item.setIcon(android.R.drawable.ic_menu_search)
-        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        menuInflater.inflate(R.menu.logged_in, menu)
         return true
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        if (!isScreenshottingEnabled()) {
+            menu?.findItem(R.id.toggleScreenshot)?.setTitle(R.string.action_enable_screenshots)
+        } else {
+            menu?.findItem(R.id.toggleScreenshot)?.setTitle(R.string.action_disable_screenshots)
+        }
+        return super.onPrepareOptionsMenu(menu)
+    }
+
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        // only item is logout
+        when (item?.itemId) {
+            R.id.logout -> logout()
+            R.id.toggleScreenshot -> if (isScreenshottingEnabled()) disableScreenshots() else enableScreenshots()
+        }
+        return true
+    }
+
+    private fun logout() {
         SApplication.instance!!.valueStore.setTokenAndMasterKey(null, null)
         SApplication.instance!!.noteStore.deleteAll()
         startActivity(Intent(this, StarterActivity::class.java))
         finish()
-        return true
+    }
+
+    private fun disableScreenshots() {
+        editor.putBoolean(IS_SCREENSHOTTING_ENABLED, false)
+        editor.commit()
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE)
+        Toast.makeText(this, R.string.toast_screenshots_disabled, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun enableScreenshots() {
+        editor.putBoolean(IS_SCREENSHOTTING_ENABLED, true)
+        editor.commit()
+        finish()
+        startActivity(intent)
+        Toast.makeText(this, R.string.toast_screenshots_enabled, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun isScreenshottingEnabled(): Boolean {
+        return prefs.getBoolean(IS_SCREENSHOTTING_ENABLED, false)
     }
 }

--- a/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
@@ -1,7 +1,9 @@
 package org.standardnotes.notes
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.preference.PreferenceManager
 import android.support.v4.app.NavUtils
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
@@ -10,11 +12,18 @@ import org.standardnotes.notes.frag.NoteFragment
 
 class NoteActivity : AppCompatActivity() {
 
+    lateinit var prefs: SharedPreferences
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE)
-//        val noteId = intent.getStringExtra("noteId")
+
+        prefs = PreferenceManager.getDefaultSharedPreferences(this)
+
+        if (!prefs.getBoolean(MainActivity.IS_SCREENSHOTTING_ENABLED, false)) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         //title = note?.title ?: "New note"
         if (savedInstanceState == null) {
             val frag: NoteFragment = NoteFragment()

--- a/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/NoteActivity.kt
@@ -1,28 +1,15 @@
 package org.standardnotes.notes
 
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.support.v4.app.NavUtils
-import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
-import android.view.WindowManager
 import org.standardnotes.notes.frag.NoteFragment
 
-class NoteActivity : AppCompatActivity() {
-
-    lateinit var prefs: SharedPreferences
+class NoteActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        prefs = PreferenceManager.getDefaultSharedPreferences(this)
-
-        if (!prefs.getBoolean(MainActivity.IS_SCREENSHOTTING_ENABLED, false)) {
-            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                    WindowManager.LayoutParams.FLAG_SECURE)
-        }
 
         //title = note?.title ?: "New note"
         if (savedInstanceState == null) {

--- a/app/src/main/java/org/standardnotes/notes/SApplication.kt
+++ b/app/src/main/java/org/standardnotes/notes/SApplication.kt
@@ -1,7 +1,6 @@
 package org.standardnotes.notes
 
 import android.app.Application
-import android.widget.Toast
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import net.danlew.android.joda.JodaTimeAndroid

--- a/app/src/main/java/org/standardnotes/notes/SettingsActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/SettingsActivity.kt
@@ -1,0 +1,34 @@
+package org.standardnotes.notes
+
+import android.os.Bundle
+import android.support.v4.app.NavUtils
+import android.support.v7.preference.PreferenceFragmentCompat
+import android.view.MenuItem
+
+class SettingsActivity : BaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        supportFragmentManager.beginTransaction().replace(android.R.id.content,
+                SettingsFragment()).commit()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> { NavUtils.navigateUpFromSameTask(this)
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    class SettingsFragment : PreferenceFragmentCompat() {
+
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            addPreferencesFromResource(R.xml.settings)
+        }
+    }
+}

--- a/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
+++ b/app/src/main/java/org/standardnotes/notes/frag/NoteListFragment.kt
@@ -26,9 +26,6 @@ import retrofit2.Callback
 import retrofit2.Response
 import java.util.*
 
-
-
-
 class NoteListFragment : Fragment() {
 
     private val REQ_EDIT_NOTE: Int = 1

--- a/app/src/main/res/menu/logged_in.xml
+++ b/app/src/main/res/menu/logged_in.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/toggleScreenshot"
+        android:title="@string/action_enable_screenshots"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/logout"
+        android:icon="@android:drawable/ic_menu_search"
+        android:title="@string/action_logout"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/menu/logged_in.xml
+++ b/app/src/main/res/menu/logged_in.xml
@@ -3,8 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/toggleScreenshot"
-        android:title="@string/action_enable_screenshots"
+        android:id="@+id/settings"
+        android:title="@string/action_settings"
         app:showAsAction="never"/>
 
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,13 @@
     <string name="error_incorrect_details">Incorrect details</string>
     <string name="error_unsupported_algorithm">Unsupported algorithm %1$s</string>
     <string name="title_activity_main">MainActivity</string>
+
+    <!-- Strings related to menu if user is logged in -->
     <string name="action_logout">Log out</string>
+    <string name="action_disable_screenshots">Disable Screenshots</string>
+    <string name="action_enable_screenshots">Enable Screenshots</string>
+    <string name="toast_screenshots_enabled">Screenshots are enabled</string>
+    <string name="toast_screenshots_disabled">Screenshots are disabled</string>
 
     <!-- Strings related to notes -->
     <string name="prompt_title">Title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,8 +22,8 @@
 
     <!-- Strings related to menu if user is logged in -->
     <string name="action_logout">Log out</string>
-    <string name="action_disable_screenshots">Disable Screenshots</string>
-    <string name="action_enable_screenshots">Enable Screenshots</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_toggle_screenshots">Enable Screenshots</string>
     <string name="toast_screenshots_enabled">Screenshots are enabled</string>
     <string name="toast_screenshots_disabled">Screenshots are disabled</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <CheckBoxPreference
+        android:key="enable_screenshots"
+        android:defaultValue="false"
+        android:title="@string/action_toggle_screenshots" />
+
+</PreferenceScreen>


### PR DESCRIPTION
This resolves issue #21. I created a menu item to quickly toggle screenshots on or off. Enabling screenshots requires the Activity to restart btw.

Also added a toast to show users that they enabled/disabled screenshots whenever they hit the toggle.

![ezgif com-resize](https://cloud.githubusercontent.com/assets/3990229/22772480/c9aba7ce-ee51-11e6-98bd-572143f12174.gif)
