### PR TITLE
Registration confirmation message 

### DIFF
--- a/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
+++ b/app/src/main/java/org/standardnotes/notes/LoginActivity.kt
@@ -123,6 +123,7 @@ class LoginActivity : AppCompatActivity() {
 
         val dialog = AlertDialog.Builder(this)
                 .setView(view)
+                .setMessage(R.string.registration_confirmation)
                 .setTitle(R.string.prompt_confirm_password)
                 .setNegativeButton(R.string.action_cancel, null)
                 .setPositiveButton(R.string.action_ok, { dialogInterface, i ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="action_sign_in_short">Sign in</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_ok">OK</string>
+    <string name="registration_confirmation">Note that because your notes are encrypted on your device using your password, Standard Notes does not have a password reset option. You cannot forget your password.</string>
     <string name="error_invalid_email">This email address is invalid</string>
     <string name="error_invalid_password">This password is too short</string>
     <string name="error_incorrect_password">This password is incorrect</string>


### PR DESCRIPTION
Add confirmation text to registration password confirmation dialog. #44 

![register_confirm_pass](https://cloud.githubusercontent.com/assets/10736861/23072435/944274bc-f529-11e6-9d86-540980235cb4.png)

