### PR TITLE
Sort tags by title, equal to desktop version

### DIFF
--- a/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
+++ b/app/src/main/java/org/standardnotes/notes/store/NoteStore.kt
@@ -213,6 +213,7 @@ class NoteStore : SQLiteOpenHelper(SApplication.instance, "note", null, CURRENT_
                 tag.deleted = cur.getInt(cur.getColumnIndex(KEY_DELETED)) == 1
                 items.add(tag)
             }
+            items.sortBy { it.title }
             return items
         }
     }
@@ -239,6 +240,7 @@ class NoteStore : SQLiteOpenHelper(SApplication.instance, "note", null, CURRENT_
                 note.deleted = cur.getInt(cur.getColumnIndex(KEY_DELETED)) == 1
                 items.add(note)
             }
+            items.sortByDescending { it.updatedAt }
             return items
         }
     }
@@ -269,6 +271,8 @@ class NoteStore : SQLiteOpenHelper(SApplication.instance, "note", null, CURRENT_
                     tag.references = getReferences(db, tag.uuid, ContentType.Note)
                 items.add(tag)
             }
+            if (!justDirty)
+                items.sortBy { it.title }
             return items
         }
     }


### PR DESCRIPTION
I've just realized tags are not sorted (default sqlite sort applied) on Android app. Fixed it