### PR TITLE
Use app package variable in manifest's provider/authorities value

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="org.standardnotes.notes.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
Doesn't affect production builds but rather allows development and production versions co-exist on one device